### PR TITLE
stub self dependency issue

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -99,7 +99,7 @@ dependencies = ["compose-cart", "compose-order"]
 dependencies = ["compose-release-cart", "compose-release-order"]
 
 [tasks.regenerate-stubs]
-dependencies = ["add-stub-dependency-order-cart", "add-stub-dependency-product-cart", "add-stub-dependency-product-order", "add-stub-dependency-pricing-cart", "add-stub-dependency-pricing-order"]
+dependencies = ["add-stub-dependency-order-cart", "add-stub-dependency-order-order", "add-stub-dependency-product-cart", "add-stub-dependency-product-order", "add-stub-dependency-pricing-cart", "add-stub-dependency-pricing-order"]
 
 [tasks.release-build-flow]
 dependencies = ["build-release", "post-build-release"]


### PR DESCRIPTION
initialize workspace command

```
golem-cli stubgen initialize-workspace --targets order  --targets product --targets pricing --callers cart --callers order
```

adding also self dependency for order (which in current case is not needed, it should be valid case and it may be needed in future)

```
% golem-cli --version
golem-cli 1.0.15
```

but then  commands 
```
cargo make regenerate-stubs
cargo make release-build-flow
```

failing on 

```
[cargo-make] INFO - Execute Command: "golem-cli" "stubgen" "add-stub-dependency" "--stub-wit-root" "order-stub/wit" "--dest-wit-root" "order/wit" "--overwrite" "--update-cargo-toml"
Both the caller and the target components are using the same package name (golem:order), which is not supported.
```
